### PR TITLE
WSDL Support tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-script: "mvn clean verify -Dtest=WSDLFromURLDirectTestIT"
+script: "mvn clean package -Dtest=WSDLFromURLDirectTestIT"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-script: "mvn clean package -Dtest=WSDLFromURLDirectTestIT"
+script: "mvn clean verify"
 
 services:
   - docker
@@ -20,14 +20,14 @@ cache:
     - '$HOME/.m2/repository'
 
 before_install:
-  - sudo sed 's/DOCKER_OPTS="/DOCKER_OPTS="--insecure-registry=docker-registry.demo.axway.com /g' -i /etc/default/docker
-  - sudo service docker restart
+  - if [ ! -f $CACHE_FILE_APIM ]; then sudo sed 's/DOCKER_OPTS="/DOCKER_OPTS="--insecure-registry=docker-registry.demo.axway.com /g' -i /etc/default/docker; fi
+  - if [ ! -f $CACHE_FILE_APIM ]; then sudo service docker restart; fi
   #- sudo apt-get update
   #- sudo apt-get install curl
   # All files in this folder will be cached for the next build
   - mkdir -p $CACHE_DIR
   # Login to the Docker-Registry
-  - docker login --username $AXWAY_DOCKER_REG_USER --password $AXWAY_DOCKER_REG_PASS docker-registry.demo.axway.com
+  - if [ ! -f $CACHE_FILE_APIM ]; then docker login --username $AXWAY_DOCKER_REG_USER --password $AXWAY_DOCKER_REG_PASS docker-registry.demo.axway.com; fi
   # Downloading the APIM-Docker-Image takes too long (Timeout 10 minutes) - Externalized to make use of travis_wait
   # In this script, we are either using the cached version or download a new Docker-Image
   - travis_wait build/pull_apim_docker_image.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-script: "mvn clean verify"
+script: "mvn clean verify -Dtest=WSDLFromURLDirectTestIT"
 
 services:
   - docker
@@ -20,14 +20,14 @@ cache:
     - '$HOME/.m2/repository'
 
 before_install:
-  - if [ ! -f $CACHE_FILE_APIM ]; then sudo sed 's/DOCKER_OPTS="/DOCKER_OPTS="--insecure-registry=docker-registry.demo.axway.com /g' -i /etc/default/docker; fi
-  - if [ ! -f $CACHE_FILE_APIM ]; then sudo service docker restart; fi
+  - sudo sed 's/DOCKER_OPTS="/DOCKER_OPTS="--insecure-registry=docker-registry.demo.axway.com /g' -i /etc/default/docker
+  - sudo service docker restart
   #- sudo apt-get update
   #- sudo apt-get install curl
   # All files in this folder will be cached for the next build
   - mkdir -p $CACHE_DIR
   # Login to the Docker-Registry
-  - if [ ! -f $CACHE_FILE_APIM ]; then docker login --username $AXWAY_DOCKER_REG_USER --password $AXWAY_DOCKER_REG_PASS docker-registry.demo.axway.com; fi
+  - docker login --username $AXWAY_DOCKER_REG_USER --password $AXWAY_DOCKER_REG_PASS docker-registry.demo.axway.com
   # Downloading the APIM-Docker-Image takes too long (Timeout 10 minutes) - Externalized to make use of travis_wait
   # In this script, we are either using the cached version or download a new Docker-Image
   - travis_wait build/pull_apim_docker_image.sh

--- a/src/main/java/com/axway/apim/App.java
+++ b/src/main/java/com/axway/apim/App.java
@@ -7,6 +7,7 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
@@ -51,13 +52,26 @@ public class App {
 			Options options = new Options();
 			Option option;
 			
-			option = new Option("a", "swagger", true, "The Swagger-API Definition (JSON-Formated):\n"
+			Option optionSwagger = new Option("a", "swagger", true, "The Swagger-API Definition (JSON-Formated):\n"
 					+ "- in local filesystem using a relativ or absolute path. Example: swagger_file.json\n"
 					+ "- a URL providing the Swagger-File. Example: [username/password@]https://any.host.com/my/path/to/swagger.json\n"
 					+ "- a file called anyname-i-want.url which contains a line with the URL (same format as above).");
-				option.setRequired(true);
-				option.setArgName("swagger_file.json");
-			options.addOption(option);
+			optionSwagger.setRequired(false);
+			optionSwagger.setArgName("swagger_file.json");
+			options.addOption(optionSwagger);
+			
+			Option optionWSDL = new Option("w", "wsdl", true, "The WSDL Definition:\n"
+					+ "- a URL providing the WSDL-File. Example: [username/password@]https://any.host.com/my/path/to/myservice.wsdl\n"
+					+ "- a file called anyname-i-want.url which contains a line with the URL (same format as above).");
+			optionWSDL.setRequired(false);
+			optionWSDL.setArgName("http://myhost/example.wsdl");
+			options.addOption(optionWSDL);
+			
+			OptionGroup optgrp = new OptionGroup();
+			optgrp.setRequired(true);
+			optgrp.addOption(optionSwagger);
+			optgrp.addOption(optionWSDL);
+			options.addOptionGroup(optgrp);
 			
 			option = new Option("c", "contract", true, "This is the JSON-Formatted API-Config containing information how to expose the API");
 				option.setRequired(true);
@@ -98,7 +112,7 @@ public class App {
 			
 			option = new Option("clientAppsMode", true, "Controls how configured Client-Applications are treated. Defaults to replace!");
 			option.setArgName("ignore|replace|add");
-			options.addOption(option);			
+			options.addOption(option);	
 			
 			CommandLineParser parser = new DefaultParser();
 			HelpFormatter formatter = new HelpFormatter();
@@ -131,7 +145,7 @@ public class App {
 			
 			APIManagerAdapter apimAdapter = new APIManagerAdapter();
 			
-			APIImportConfig contract = new APIImportConfig(params.getOptionValue("contract"), params.getOptionValue("stage"), params.getOptionValue("swagger"));
+			APIImportConfig contract = new APIImportConfig(params.getOptionValue("contract"), params.getOptionValue("stage"), params.getOptionValue("swagger"),params.getOptionValue("wsdl"));
 			IAPIDefinition desiredAPI = contract.getImportAPIDefinition();
 			IAPIDefinition actualAPI = APIManagerAdapter.getAPIManagerAPI(APIManagerAdapter.getExistingAPI(desiredAPI.getPath()), desiredAPI);
 			APIChangeState changeActions = new APIChangeState(actualAPI, desiredAPI);			

--- a/src/main/java/com/axway/apim/actions/tasks/ImportBackendAPI.java
+++ b/src/main/java/com/axway/apim/actions/tasks/ImportBackendAPI.java
@@ -57,6 +57,7 @@ public class ImportBackendAPI extends AbstractAPIMTask implements IResponseParse
 			this.desiredState.setWsdlURL(extractURI(wsdlUrl));
 			username=extractUsername(wsdlUrl);
 			pass=extractPassword(wsdlUrl);
+			LOG.info("{}",this.desiredState.getWsdlURL());
 		}
 		
 		URIBuilder uriBuilder = new URIBuilder(cmd.getAPIManagerURL()).setPath(RestAPICall.API_VERSION+"/apirepo/importFromUrl/")

--- a/src/main/java/com/axway/apim/lib/ErrorCode.java
+++ b/src/main/java/com/axway/apim/lib/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
 	ACCESS_ORGANIZATION_ERR		(59, "An error happens while managing organization permission."),
 	API_MANAGER_COMMUNICATION	(60, "API-Manager communication error."),
 	CANT_READ_SWAGGER_FILE		(65, "Can't read Swagger-File."),
+	CANT_READ_WSDL_FILE			(66, "Can't read Wsdl-File."),
 	CANT_READ_CONFIG_FILE		(70, "Can't read Config-File."),
 	UNSUPPORTED_FEATURE			(75, "Unsupported feature or operation used."),
 	CANT_CREATE_STATE_CHANGE	(80, "Cannot use Import & Existing API to create change state."),

--- a/src/main/java/com/axway/apim/swagger/APIImportConfig.java
+++ b/src/main/java/com/axway/apim/swagger/APIImportConfig.java
@@ -377,7 +377,7 @@ public class APIImportConfig {
 	private byte[] getSwaggerContent() throws AppException {
 		try {
 			InputStream stream = getSwaggerAsStream();
-			Reader reader = new InputStreamReader(stream);
+			Reader reader = new InputStreamReader(stream,StandardCharsets.UTF_8);
 			return IOUtils.toByteArray(reader,StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new AppException("Can't read swagger-file from file", ErrorCode.CANT_READ_SWAGGER_FILE, e);
@@ -451,7 +451,7 @@ public class APIImportConfig {
                     int status = response.getStatusLine().getStatusCode();
                     if (status >= 200 && status < 300) {
                         HttpEntity entity = response.getEntity();
-                        return entity != null ? EntityUtils.toString(entity) : null;
+                        return entity != null ? EntityUtils.toString(entity,StandardCharsets.UTF_8) : null;
                     } else {
                         throw new ClientProtocolException("Unexpected response status: " + status);
                     }

--- a/src/main/java/com/axway/apim/swagger/APIImportConfig.java
+++ b/src/main/java/com/axway/apim/swagger/APIImportConfig.java
@@ -8,6 +8,8 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -374,7 +376,9 @@ public class APIImportConfig {
 	
 	private byte[] getSwaggerContent() throws AppException {
 		try {
-			return IOUtils.toByteArray(getSwaggerAsStream());
+			InputStream stream = getSwaggerAsStream();
+			Reader reader = new InputStreamReader(stream);
+			return IOUtils.toByteArray(reader,StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new AppException("Can't read swagger-file from file", ErrorCode.CANT_READ_SWAGGER_FILE, e);
 		}

--- a/src/main/java/com/axway/apim/swagger/APIImportConfig.java
+++ b/src/main/java/com/axway/apim/swagger/APIImportConfig.java
@@ -67,6 +67,8 @@ public class APIImportConfig {
 	private String apiConfig;
 	
 	private String stage;
+	
+	private String wsdlURL;
 
 	/**
 	 * Constructs the APIImportConfig 
@@ -75,11 +77,12 @@ public class APIImportConfig {
 	 * @param pathToSwagger
 	 * @throws AppException
 	 */
-	public APIImportConfig(String apiContract, String stage, String pathToSwagger) throws AppException {
+	public APIImportConfig(String apiContract, String stage, String pathToSwagger,String wsdlURL) throws AppException {
 		super();
 		this.apiConfig = apiContract;
 		this.stage = stage;
 		this.pathToSwagger = pathToSwagger;
+		this.wsdlURL=wsdlURL;
 	}
 	
 	/**
@@ -108,7 +111,14 @@ public class APIImportConfig {
 				stagedConfig = baseConfig;
 			}
 			addDefaultPassthroughSecurityProfile(stagedConfig);
-			stagedConfig.setSwaggerDefinition(new APISwaggerDefinion(getSwaggerContent()));
+			if (this.wsdlURL!=null) {
+				stagedConfig.setWsdlURL(this.wsdlURL);
+				//we use the pathToSwagger even if it's a wsdl url
+				pathToSwagger=this.wsdlURL;
+				stagedConfig.setSwaggerDefinition(new APISwaggerDefinion(getSwaggerContent()));
+			} else {
+				stagedConfig.setSwaggerDefinition(new APISwaggerDefinion(getSwaggerContent()));
+			}
 			addImageContent(stagedConfig);
 			validateCustomProperties(stagedConfig);
 			validateDescription(stagedConfig);

--- a/src/main/java/com/axway/apim/swagger/APIManagerAdapter.java
+++ b/src/main/java/com/axway/apim/swagger/APIManagerAdapter.java
@@ -2,8 +2,11 @@ package com.axway.apim.swagger;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -493,7 +496,8 @@ public class APIManagerAdapter {
 					.setParameter("original", "true").build();
 			RestAPICall getRequest = new GETRequest(uri, null);
 			InputStream response = getRequest.execute().getEntity().getContent();
-			return IOUtils.toByteArray(response);
+			Reader reader = new InputStreamReader(response);
+			return IOUtils.toByteArray(reader,StandardCharsets.UTF_8);
 		} catch (Exception e) {
 			throw new AppException("Can't read Swagger-File.", ErrorCode.CANT_READ_SWAGGER_FILE, e);
 		}

--- a/src/main/java/com/axway/apim/swagger/APIManagerAdapter.java
+++ b/src/main/java/com/axway/apim/swagger/APIManagerAdapter.java
@@ -15,6 +15,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.naming.ldap.StartTlsResponse;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -495,9 +497,12 @@ public class APIManagerAdapter {
 			uri = new URIBuilder(CommandParameters.getInstance().getAPIManagerURL()).setPath(RestAPICall.API_VERSION + "/apirepo/"+backendApiID+"/download")
 					.setParameter("original", "true").build();
 			RestAPICall getRequest = new GETRequest(uri, null);
-			InputStream response = getRequest.execute().getEntity().getContent();
-			Reader reader = new InputStreamReader(response);
-			return IOUtils.toByteArray(reader,StandardCharsets.UTF_8);
+			HttpResponse response=getRequest.execute();
+			//InputStream response = getRequest.execute().getEntity().getContent();
+			//Reader reader = new InputStreamReader(response);
+			String res = EntityUtils.toString(response.getEntity(),StandardCharsets.UTF_8);
+			return res.getBytes(StandardCharsets.UTF_8);
+			//return IOUtils.toByteArray(res);
 		} catch (Exception e) {
 			throw new AppException("Can't read Swagger-File.", ErrorCode.CANT_READ_SWAGGER_FILE, e);
 		}

--- a/src/main/java/com/axway/apim/swagger/api/APIBaseDefinition.java
+++ b/src/main/java/com/axway/apim/swagger/api/APIBaseDefinition.java
@@ -47,4 +47,16 @@ public class APIBaseDefinition extends AbstractAPIDefinition implements IAPIDefi
 		// TODO Auto-generated method stub
 		return null;
 	}
+
+	@Override
+	public void setWsdlURL(String wsdlURL) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public String getWsdlURL() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/src/main/java/com/axway/apim/swagger/api/APIImportDefinition.java
+++ b/src/main/java/com/axway/apim/swagger/api/APIImportDefinition.java
@@ -36,6 +36,8 @@ public class APIImportDefinition extends AbstractAPIDefinition implements IAPIDe
 	
 	private boolean requestForAllOrgs = false;
 	
+	private String wsdlURL = null;
+	
 	public APIImportDefinition() throws AppException {
 		super();
 	}
@@ -116,5 +118,16 @@ public class APIImportDefinition extends AbstractAPIDefinition implements IAPIDe
 	 */
 	public void setRequestForAllOrgs(boolean requestForAllOrgs) {
 		this.requestForAllOrgs = requestForAllOrgs;
+	}
+
+	@Override
+	public void setWsdlURL(String wsdlURL) {
+		this.wsdlURL=wsdlURL;
+		
+	}
+
+	@Override
+	public String getWsdlURL() {
+		return this.wsdlURL;
 	}
 }

--- a/src/main/java/com/axway/apim/swagger/api/APIManagerAPI.java
+++ b/src/main/java/com/axway/apim/swagger/api/APIManagerAPI.java
@@ -43,4 +43,16 @@ public class APIManagerAPI extends AbstractAPIDefinition implements IAPIDefiniti
 				&& this.deprecated.equals("true")) return IAPIDefinition.STATE_DEPRECATED;
 		return super.getState();
 	}
+
+	@Override
+	public void setWsdlURL(String wsdlURL) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public String getWsdlURL() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/src/main/java/com/axway/apim/swagger/api/IAPIDefinition.java
+++ b/src/main/java/com/axway/apim/swagger/api/IAPIDefinition.java
@@ -100,4 +100,8 @@ public interface IAPIDefinition {
 	public void setApplications(List<ClientApplication> clientApplications);
 	
 	public Map<String, ServiceProfile> getServiceProfiles();
+	
+	public void setWsdlURL(String wsdlURL);
+	
+	public String getWsdlURL();
 }

--- a/src/test/java/com/axway/apim/test/WSDLImportTestAction.java
+++ b/src/test/java/com/axway/apim/test/WSDLImportTestAction.java
@@ -1,0 +1,89 @@
+package com.axway.apim.test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.axway.apim.App;
+import com.axway.apim.lib.CommandParameters;
+import com.consol.citrus.actions.AbstractTestAction;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.exceptions.CitrusRuntimeException;
+import com.consol.citrus.exceptions.ValidationException;
+
+public class WSDLImportTestAction extends AbstractTestAction {
+	
+	private static Logger LOG = LoggerFactory.getLogger(WSDLImportTestAction.class);
+	
+	//private String swaggerFile;
+	
+	//private String configFile;
+	
+	@Override
+	public void doExecute(TestContext context) {
+		String wsdlURL 			= context.getVariable("wsdlURL");
+		String configFile 			= context.getVariable("configFile");
+		String stage				= null;
+
+		//String configFile = replaceDynamicContentInFile(origConfigFile, context);
+		LOG.info("Using WSDL-URL: " + wsdlURL);
+		LOG.info("Using configFile-File: " + configFile);
+		int expectedReturnCode = 0;
+		try {
+			expectedReturnCode 	= Integer.parseInt(context.getVariable("expectedReturnCode"));
+		} catch (Exception ignore) {};
+		
+		String enforce = "false";
+		String ignoreQuotas = "false";
+		String clientOrgsMode = CommandParameters.MODE_REPLACE;
+		String clientAppsMode = CommandParameters.MODE_REPLACE;;
+		
+		try {
+			enforce = context.getVariable("enforce");
+		} catch (Exception ignore) {};
+		try {
+			ignoreQuotas = context.getVariable("ignoreQuotas");
+		} catch (Exception ignore) {};
+		try {
+			clientOrgsMode = context.getVariable("clientOrgsMode");
+		} catch (Exception ignore) {};
+		try {
+			clientAppsMode = context.getVariable("clientAppsMode");
+		} catch (Exception ignore) {};
+		
+		if(stage==null) {
+			stage = "NOT_SET";
+		} else {
+			// We need to prepare the dynamic staging file used during the test.
+			//String stageConfigFile = origConfigFile.substring(0, origConfigFile.lastIndexOf(".")+1) + stage + origConfigFile.substring(origConfigFile.lastIndexOf("."));
+			// This creates the dynamic staging config file! (Fort testing, we also support reading out of a file directly)
+			//stage = replaceDynamicContentInFile(stageConfigFile, context);
+		}
+
+		String[] args = new String[] { 
+				"-w", wsdlURL, 
+				"-c", configFile, 
+				"-h", context.replaceDynamicContentInString("${apiManagerHost}"), 
+				"-p", context.replaceDynamicContentInString("${apiManagerPass}"), 
+				"-u", context.replaceDynamicContentInString("${apiManagerUser}"),
+				"-s", stage, 
+				"-f", enforce, 
+				"-iq", ignoreQuotas, 
+				"-clientOrgsMode", clientOrgsMode, 
+				"-clientAppsMode", clientAppsMode};
+		
+		int rc = App.run(args);
+		if(expectedReturnCode!=rc) {
+			throw new ValidationException("Expected RC was: " + expectedReturnCode + " but got: " + rc);
+		}
+	}
+	
+}

--- a/src/test/java/com/axway/apim/test/basic/WSDLFromURLDirectTestIT.java
+++ b/src/test/java/com/axway/apim/test/basic/WSDLFromURLDirectTestIT.java
@@ -1,0 +1,60 @@
+package com.axway.apim.test.basic;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.testng.annotations.Test;
+
+import com.axway.apim.test.WSDLImportTestAction;
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.dsl.testng.TestNGCitrusTestDesigner;
+import com.consol.citrus.functions.core.RandomNumberFunction;
+import com.consol.citrus.message.MessageType;
+
+@Test(testName="WSDLFromURLDirectTestIT")
+public class WSDLFromURLDirectTestIT extends TestNGCitrusTestDesigner {
+	
+	@Autowired
+	private WSDLImportTestAction wsdlImport;
+	
+	@CitrusTest(name = "WSDLFromURLDirectTestIT")
+	public void setupDevOrgTest() {
+		description("Validates a WSDL-File can be taken from a URL using the direct instruction.");
+		
+		variable("apiNumber", RandomNumberFunction.getRandomNumber(3, true));
+		variable("apiPath", "/direct-url-wsdl-${apiNumber}");
+		variable("apiName", "Direct-URL-WSDL from URL-${apiNumber}");
+		
+
+		
+		echo("####### Importing API: '${apiName}' on path: '${apiPath}' for the first time from URL #######");
+		createVariable("wsdlURL", "http://www.dneonline.com/calculator.asmx?wsdl");
+		createVariable("configFile", "/com/axway/apim/test/files/basic/wsdl-minimal-config.json");
+		createVariable("status", "unpublished");
+		createVariable("expectedReturnCode", "0");
+		action(wsdlImport);
+		
+		echo("####### Validate API: '${apiName}' on path: '${apiPath}' has been imported #######");
+		http().client("apiManager")
+			.send()
+			.get("/proxies")
+			.name("api")
+			.header("Content-Type", "application/json");
+
+		http().client("apiManager")
+			.receive()
+			.response(HttpStatus.OK)
+			.messageType(MessageType.JSON)
+			.validate("$.[?(@.path=='${apiPath}')].name", "${apiName}")
+			.validate("$.[?(@.path=='${apiPath}')].state", "unpublished")
+			.extractFromPayload("$.[?(@.path=='${apiPath}')].id", "apiId");
+		
+		echo("####### Re-Import API from URL without a change #######");
+		createVariable("wsdlURL", "http://www.dneonline.com/calculator.asmx?wsdl");
+		createVariable("configFile", "/com/axway/apim/test/files/basic/wsdl-minimal-config.json");
+		createVariable("status", "unpublished");
+		createVariable("expectedReturnCode", "10");
+		action(wsdlImport);
+
+	}
+
+}

--- a/src/test/java/com/axway/apim/test/basic/WSDLFromURLDirectTestIT.java
+++ b/src/test/java/com/axway/apim/test/basic/WSDLFromURLDirectTestIT.java
@@ -67,6 +67,34 @@ public class WSDLFromURLDirectTestIT extends TestNGCitrusTestDesigner {
 		createVariable("status", "unpublished");
 		createVariable("expectedReturnCode", "10");
 		action(wsdlImport);
+		
+		echo("####### Setting the status to Published #######");
+		createVariable("wsdlURL", "http://www.dneonline.com/calculator.asmx?wsdl");
+		createVariable("configFile", "/com/axway/apim/test/files/basic/wsdl-minimal-config.json");
+		createVariable("status", "published");
+		createVariable("expectedReturnCode", "0");
+		action(wsdlImport);
+		
+		echo("####### Validate API: '${apiName}' on path: '${apiPath}' has been imported #######");
+		http().client("apiManager")
+			.send()
+			.get("/proxies")
+			.name("api")
+			.header("Content-Type", "application/json");
+
+		http().client("apiManager")
+			.receive()
+			.response(HttpStatus.OK)
+			.messageType(MessageType.JSON)
+			.validate("$.[?(@.id=='${apiId}')].name", "${apiName}")
+			.validate("$.[?(@.id=='${apiId}')].state", "published");
+		
+		echo("####### Now performing a change, which required to Re-Create the API #######");
+		createVariable("wsdlURL", "http://www.dneonline.com/calculator.asmx?wsdl");
+		createVariable("configFile", "/com/axway/apim/test/files/basic/wsdl-minimal-config-with-tags.json");
+		createVariable("status", "published");
+		createVariable("expectedReturnCode", "0");
+		action(wsdlImport);
 
 	}
 

--- a/src/test/java/com/axway/apim/test/basic/WSDLFromURLDirectTestIT.java
+++ b/src/test/java/com/axway/apim/test/basic/WSDLFromURLDirectTestIT.java
@@ -1,5 +1,11 @@
 package com.axway.apim.test.basic;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.testng.annotations.Test;
@@ -13,6 +19,8 @@ import com.consol.citrus.message.MessageType;
 @Test(testName="WSDLFromURLDirectTestIT")
 public class WSDLFromURLDirectTestIT extends TestNGCitrusTestDesigner {
 	
+	private static Logger LOG = LoggerFactory.getLogger(WSDLFromURLDirectTestIT.class);
+	
 	@Autowired
 	private WSDLImportTestAction wsdlImport;
 	
@@ -20,6 +28,11 @@ public class WSDLFromURLDirectTestIT extends TestNGCitrusTestDesigner {
 	public void setupDevOrgTest() {
 		description("Validates a WSDL-File can be taken from a URL using the direct instruction.");
 		
+		LOG.info("Default Charset=" + Charset.defaultCharset());
+		LOG.info("file.encoding=" + System.getProperty("file.encoding"));
+		LOG.info("Default Charset=" + Charset.defaultCharset());
+		LOG.info("Default Charset in Use=" + getDefaultCharSet());
+    		
 		variable("apiNumber", RandomNumberFunction.getRandomNumber(3, true));
 		variable("apiPath", "/direct-url-wsdl-${apiNumber}");
 		variable("apiName", "Direct-URL-WSDL from URL-${apiNumber}");
@@ -55,6 +68,12 @@ public class WSDLFromURLDirectTestIT extends TestNGCitrusTestDesigner {
 		createVariable("expectedReturnCode", "10");
 		action(wsdlImport);
 
+	}
+
+	private  String getDefaultCharSet() {
+		OutputStreamWriter writer = new OutputStreamWriter(new ByteArrayOutputStream());
+		String enc = writer.getEncoding();
+		return enc;
 	}
 
 }

--- a/src/test/java/com/axway/apim/test/basic/WSDLFromURLRefFileTestIT.java
+++ b/src/test/java/com/axway/apim/test/basic/WSDLFromURLRefFileTestIT.java
@@ -1,0 +1,60 @@
+package com.axway.apim.test.basic;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.testng.annotations.Test;
+
+import com.axway.apim.test.SwaggerImportTestAction;
+import com.axway.apim.test.WSDLImportTestAction;
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.dsl.testng.TestNGCitrusTestDesigner;
+import com.consol.citrus.functions.core.RandomNumberFunction;
+import com.consol.citrus.message.MessageType;
+
+@Test(testName="WSDLFromURLRefFileTestIT")
+public class WSDLFromURLRefFileTestIT extends TestNGCitrusTestDesigner {
+	
+	@Autowired
+	private WSDLImportTestAction wsdlImport;
+	
+	@CitrusTest(name = "WSDLFromURLRefFileTestIT")
+	public void setupDevOrgTest() {
+		description("Validates a WSDL-File can be taken from a URL using a REF-File.");
+		
+		variable("apiNumber", RandomNumberFunction.getRandomNumber(3, true));
+		variable("apiPath", "/ref-file-wsdl-${apiNumber}");
+		variable("apiName", "Ref-File-WSDL from URL-${apiNumber}");
+		
+
+		
+		echo("####### Importing API: '${apiName}' on path: '${apiPath}' for the first time from URL #######");
+		createVariable("wsdlURL", "/com/axway/apim/test/files/basic/wsdl-file-with-username.url");
+		createVariable("configFile", "/com/axway/apim/test/files/basic/wsdl-minimal-config.json");
+		createVariable("status", "unpublished");
+		createVariable("expectedReturnCode", "0");
+		action(wsdlImport);
+		
+		echo("####### Validate API: '${apiName}' on path: '${apiPath}' has been imported #######");
+		http().client("apiManager")
+			.send()
+			.get("/proxies")
+			.name("api")
+			.header("Content-Type", "application/json");
+
+		http().client("apiManager")
+			.receive()
+			.response(HttpStatus.OK)
+			.messageType(MessageType.JSON)
+			.validate("$.[?(@.path=='${apiPath}')].name", "${apiName}")
+			.validate("$.[?(@.path=='${apiPath}')].state", "unpublished")
+			.extractFromPayload("$.[?(@.path=='${apiPath}')].id", "apiId");
+		
+		echo("####### Re-Import API from URL without a change #######");
+		createVariable("wsdlURL", "/com/axway/apim/test/files/basic/wsdl-file-with-username.url");
+		createVariable("configFile", "/com/axway/apim/test/files/basic/wsdl-minimal-config.json");
+		createVariable("status", "unpublished");
+		createVariable("expectedReturnCode", "10");
+		action(wsdlImport);
+	}
+
+}

--- a/src/test/resources/citrus-context.xml
+++ b/src/test/resources/citrus-context.xml
@@ -23,6 +23,7 @@
     </bean>
     
     <bean class="com.axway.apim.test.SwaggerImportTestAction"/>
+    <bean class="com.axway.apim.test.WSDLImportTestAction"/>
     <bean id="myBeforeSuite" class="com.axway.apim.test.setup.InitializationTestIT"/>
     
     <citrus:global-variables>

--- a/src/test/resources/com/axway/apim/test/files/basic/wsdl-file-with-username.url
+++ b/src/test/resources/com/axway/apim/test/files/basic/wsdl-file-with-username.url
@@ -1,0 +1,1 @@
+user/password@http://www.dneonline.com/calculator.asmx?wsdl

--- a/src/test/resources/com/axway/apim/test/files/basic/wsdl-file-with-username.url
+++ b/src/test/resources/com/axway/apim/test/files/basic/wsdl-file-with-username.url
@@ -1,1 +1,1 @@
-user/password@http://www.dneonline.com/calculator.asmx?wsdl
+http://www.dneonline.com/calculator.asmx?wsdl

--- a/src/test/resources/com/axway/apim/test/files/basic/wsdl-minimal-config.json
+++ b/src/test/resources/com/axway/apim/test/files/basic/wsdl-minimal-config.json
@@ -1,0 +1,8 @@
+	
+{
+	"name": "${apiName}",
+	"path": "${apiPath}",
+	"state": "${status}",
+	"version": "1.0.0",
+	"organization": "API Development ${orgNumber}"
+}

--- a/src/test/resources/com/axway/apim/test/files/basic/wsdl-minimal-config.json
+++ b/src/test/resources/com/axway/apim/test/files/basic/wsdl-minimal-config.json
@@ -1,4 +1,3 @@
-	
 {
 	"name": "${apiName}",
 	"path": "${apiPath}",

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -41,7 +41,7 @@
 
   <!-- Limit the org.apache logger to INFO as its DEBUG is verbose -->
   <logger name="org.apache">
-    <level value="INFO"/>
+    <level value="DEBUG"/>
   </logger>
   <!-- 
   <logger name="com.consol.citrus.channel.MessageSelectingQueueChannel">
@@ -53,7 +53,7 @@
   </logger>
   
   <logger name="com.axway.apim.swagger">
-	<level value="INFO"/>
+	<level value="DEBUG"/>
   </logger>
 
   <!-- ======================= -->

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -41,7 +41,7 @@
 
   <!-- Limit the org.apache logger to INFO as its DEBUG is verbose -->
   <logger name="org.apache">
-    <level value="DEBUG"/>
+    <level value="INFO"/>
   </logger>
   <!-- 
   <logger name="com.consol.citrus.channel.MessageSelectingQueueChannel">
@@ -53,7 +53,7 @@
   </logger>
   
   <logger name="com.axway.apim.swagger">
-	<level value="DEBUG"/>
+	<level value="INFO"/>
   </logger>
 
   <!-- ======================= -->


### PR DESCRIPTION
These commits enable the tool to handle SOAP Service registration automation in API Manager,
The command line interface contains a new parameter to specify the URL of wsdl to import in API Manager

In the current version of API Manager REST API the import of SOAP Backend API is only supported with URL, not by file (as per REST API with swagger file)