### PR TITLE
Ignore any custom properties in organization

### DIFF
--- a/src/main/java/com/axway/apim/swagger/api/properties/organization/Organization.java
+++ b/src/main/java/com/axway/apim/swagger/api/properties/organization/Organization.java
@@ -2,6 +2,9 @@ package com.axway.apim.swagger.api.properties.organization;
 
 import org.apache.commons.lang.StringUtils;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Organization {
 	
 	private String id;


### PR DESCRIPTION
The tool fails with parse error if the organization has any custom properties. This PR will fix this issue.