### PR TITLE
Handling for VHost improved.

### DIFF
--- a/modules/swagger-promote-core/src/main/java/com/axway/apim/actions/UpdateExistingAPI.java
+++ b/modules/swagger-promote-core/src/main/java/com/axway/apim/actions/UpdateExistingAPI.java
@@ -44,11 +44,12 @@ public class UpdateExistingAPI {
 		}
 		
 		// This is special, as the status is not a property and requires some additional actions!
+		UpdateAPIStatus statusUpdate = new UpdateAPIStatus(changes.getDesiredAPI(), changes.getActualAPI());
 		if(changes.getNonBreakingChanges().contains("state")) {
-			new UpdateAPIStatus(changes.getDesiredAPI(), changes.getActualAPI()).execute();
+			statusUpdate.execute();
 		}
 		
-		vHostHandler.handleVHost(changes.getDesiredAPI(), changes.getActualAPI());
+		vHostHandler.handleVHost(changes.getDesiredAPI(), changes.getActualAPI(), statusUpdate.isUpdateVHostRequired());
 		
 		new UpdateQuotaConfiguration(changes.getDesiredAPI(), changes.getActualAPI()).execute();
 		new ManageClientOrgs(changes.getDesiredAPI(), changes.getActualAPI()).execute(false);

--- a/modules/swagger-promote-core/src/main/java/com/axway/apim/actions/tasks/props/VhostPropertyHandler.java
+++ b/modules/swagger-promote-core/src/main/java/com/axway/apim/actions/tasks/props/VhostPropertyHandler.java
@@ -10,6 +10,7 @@ import com.axway.apim.actions.tasks.UpdateAPIProxy;
 import com.axway.apim.lib.AppException;
 import com.axway.apim.lib.ErrorCode;
 import com.axway.apim.lib.ErrorState;
+import com.axway.apim.swagger.APIManagerAdapter;
 import com.axway.apim.swagger.api.state.IAPI;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -33,8 +34,12 @@ public class VhostPropertyHandler implements PropertyHandler {
 	}
 	
 	public void handleVHost(IAPI desiredAPI, IAPI actualAPI) throws AppException {
-		if(updateVhost) {
-			if(actualAPI.getState().equals(IAPI.STATE_UNPUBLISHED)) {
+		handleVHost(desiredAPI, actualAPI, false);
+	}
+	
+	public void handleVHost(IAPI desiredAPI, IAPI actualAPI, boolean forceUpdate) throws AppException {
+		if(updateVhost || forceUpdate) {
+			if(!APIManagerAdapter.hasAPIManagerVersion("7.6.2 SP3") && actualAPI.getState().equals(IAPI.STATE_UNPUBLISHED)) {
 				ErrorState.getInstance().setError("Can't update V-Host to: "+desiredAPI.getVhost()+" on unpublished API!", ErrorCode.CANT_SETUP_VHOST, false);
 				throw new AppException("Can't update V-Host to: "+desiredAPI.getVhost()+" on unpublished API!", 
 						ErrorCode.CANT_SETUP_VHOST);

--- a/modules/swagger-promote-core/src/test/java/com/axway/apim/test/vhost/VhostConfigOrgWithVHostTestIT.java
+++ b/modules/swagger-promote-core/src/test/java/com/axway/apim/test/vhost/VhostConfigOrgWithVHostTestIT.java
@@ -1,0 +1,79 @@
+package com.axway.apim.test.vhost;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import com.axway.apim.lib.AppException;
+import com.axway.apim.test.ImportTestAction;
+import com.consol.citrus.annotations.CitrusResource;
+import com.consol.citrus.annotations.CitrusTest;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.dsl.testng.TestNGCitrusTestRunner;
+import com.consol.citrus.functions.core.RandomNumberFunction;
+import com.consol.citrus.message.MessageType;
+
+@Test
+public class VhostConfigOrgWithVHostTestIT extends TestNGCitrusTestRunner {
+	
+	private ImportTestAction swaggerImport;
+	
+	@CitrusTest
+	@Test @Parameters("context")
+	public void run(@Optional @CitrusResource TestContext context) throws IOException, AppException {
+		swaggerImport = new ImportTestAction();
+		description("Test VHost with an organization having a Default virtual host");
+		
+		variable("apiNumber", RandomNumberFunction.getRandomNumber(3, true));
+		variable("apiPath", "/vhost-org-test-${apiNumber}");
+		variable("apiName", "VHost Org-Test ${apiNumber}");
+		variable("vhost", "abc.company.com");
+		variable("vhostOrgName", "VHost Org ${orgNumber}");
+		// Directly use an admin-account, otherwise the OrgAdmin organization is used by default
+		variable("oadminUsername1", "apiadmin"); 
+		variable("oadminPassword1", "changeme");
+		
+		http(builder -> builder.client("apiManager").send().post("/organizations").header("Content-Type", "application/json")
+				.payload("{\"name\": \"${vhostOrgName}\", \"description\": \"Org 1 with dev permission and VHost\", \"enabled\": true, \"development\": true, \"virtualHost\": \"${vhost}\" }"));
+		http(builder -> builder.client("apiManager").receive().response(HttpStatus.CREATED).messageType(MessageType.JSON)
+				.validate("$.name", "${vhostOrgName}")
+				.extractFromPayload("$.id", "vhostOrgId"));
+
+		echo("####### Importing API: '${apiName}' on path: '${apiPath}' with following settings: #######");
+		createVariable("status", "published");
+		createVariable("vhost", "${vhost}"); // Using the same V-Host as configured for the organization.
+		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/security/petstore.json");
+		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/vhost/2_vhost-config.json");
+		createVariable("expectedReturnCode", "0");
+		swaggerImport.doExecute(context);
+		
+		// Validate the API has been imported correctly
+		echo("####### Validate the API has been imported correctly #######");
+		http(builder -> builder.client("apiManager").send().get("/proxies").header("Content-Type", "application/json"));
+		http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
+				.validate("$.[?(@.path=='${apiPath}')].name", "${apiName}")
+				.validate("$.[?(@.path=='${apiPath}')].state", "${status}")
+				.validate("$.[?(@.path=='${apiPath}')].vhost", "${vhost}")
+				.extractFromPayload("$.[?(@.path=='${apiPath}')].id", "apiId"));
+		
+		echo("####### Manually unpublish this API! #######");
+		http(builder -> builder.client("apiManager").send().post("/proxies/${apiId}/unpublish").header("Content-Type", "application/json"));
+		http(builder -> builder.client("apiManager").receive().response(HttpStatus.CREATED).messageType(MessageType.JSON)
+				.validate("$.[?(@.path=='${apiPath}')].state", "unpublished"));
+		
+		echo("####### Re-Import the API and the VHost must be configured again #######");
+		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/security/petstore.json");
+		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/vhost/2_vhost-config.json");
+		createVariable("expectedReturnCode", "0");
+		swaggerImport.doExecute(context);
+		
+		http(builder -> builder.client("apiManager").send().get("/proxies/${apiId}").header("Content-Type", "application/json"));
+		http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
+				.validate("$.[?(@.id=='${apiId}')].name", "${apiName}")
+				.validate("$.[?(@.id=='${apiId}')].state", "${status}")
+				.validate("$.[?(@.id=='${apiId}')].vhost", "${vhost}"));
+	}
+}

--- a/modules/swagger-promote-core/src/test/java/com/axway/apim/test/vhost/VhostConfigTestIT.java
+++ b/modules/swagger-promote-core/src/test/java/com/axway/apim/test/vhost/VhostConfigTestIT.java
@@ -1,67 +1,77 @@
 package com.axway.apim.test.vhost;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import java.io.IOException;
+
 import org.springframework.http.HttpStatus;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+import com.axway.apim.lib.AppException;
+import com.axway.apim.swagger.APIManagerAdapter;
 import com.axway.apim.test.ImportTestAction;
+import com.consol.citrus.annotations.CitrusResource;
 import com.consol.citrus.annotations.CitrusTest;
-import com.consol.citrus.dsl.testng.TestNGCitrusTestDesigner;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.dsl.testng.TestNGCitrusTestRunner;
 import com.consol.citrus.functions.core.RandomNumberFunction;
 import com.consol.citrus.message.MessageType;
 
-@Test(testName="VhostConfigTest")
-public class VhostConfigTestIT extends TestNGCitrusTestDesigner {
-	
-	@Autowired
+@Test
+public class VhostConfigTestIT extends TestNGCitrusTestRunner {
+
 	private ImportTestAction swaggerImport;
 	
-	@CitrusTest(name = "VhostConfigTest")
-	public void run() {
-		description("Test a Request-Policy");
+	@CitrusTest
+	@Test @Parameters("context")
+	public void run(@Optional @CitrusResource TestContext context) throws IOException, AppException {
+		swaggerImport = new ImportTestAction();
+		description("Validate VHosts are handled correctly");
 		
 		variable("apiNumber", RandomNumberFunction.getRandomNumber(3, true));
 		variable("apiPath", "/vhost-test-${apiNumber}");
 		variable("apiName", "VHost Test ${apiNumber}");
-		variable("status", "unpublished");
-		
 
-		echo("####### Importing API: '${apiName}' on path: '${apiPath}' with following settings: #######");
-		createVariable("status", "unpublished");
-		createVariable("vhost", "api123.customer.com");
-		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/security/petstore.json");
-		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/vhost/1_vhost-config.json");
-		createVariable("expectedReturnCode", "87");
-		action(swaggerImport);
-		
-		// Search for the API anyway!
-		echo("####### Validate the API has been rolled back #######");
-		http().client("apiManager").send().get("/proxies").name("api").header("Content-Type", "application/json");
-
-		http().client("apiManager")
-			.receive()
-			.response(HttpStatus.OK)
-			.messageType(MessageType.JSON)
-			.validate("$.*.name", "@assertThat(not(containsString(${apiName})))@");
-		
 		echo("####### Importing API: '${apiName}' on path: '${apiPath}' with following settings: #######");
 		createVariable("status", "published");
 		createVariable("vhost", "api123.customer.com");
 		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/security/petstore.json");
 		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/vhost/1_vhost-config.json");
 		createVariable("expectedReturnCode", "0");
-		action(swaggerImport);
-		
-		// Search for the API anyway!
-		echo("####### Validate API: '${apiName}' on path: '${apiPath}' has correct settings #######");
-		http().client("apiManager").send().get("/proxies").name("api").header("Content-Type", "application/json");
+		swaggerImport.doExecute(context);
 
-		http().client("apiManager")
-			.receive()
-			.response(HttpStatus.OK)
-			.messageType(MessageType.JSON)
+		echo("####### Validate API: '${apiName}' on path: '${apiPath}' has correct settings #######");
+		http(builder -> builder.client("apiManager").send().get("/proxies").header("Content-Type", "application/json"));
+
+		http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
 			.validate("$.[?(@.path=='${apiPath}')].name", "${apiName}")
 			.validate("$.[?(@.path=='${apiPath}')].state", "published")
-			.validate("$.[?(@.path=='${apiPath}')].vhost", "api123.customer.com");
+			.validate("$.[?(@.path=='${apiPath}')].vhost", "api123.customer.com"));
+
+		echo("####### Importing API: '${apiName}' on path: '${apiPath}' with following settings: #######");
+		createVariable("status", "unpublished");
+		createVariable("vhost", "api123.customer.com");
+		createVariable("enforce", "true"); // as we are going back from published to unpublished
+		createVariable(ImportTestAction.API_DEFINITION,  "/com/axway/apim/test/files/security/petstore.json");
+		createVariable(ImportTestAction.API_CONFIG,  "/com/axway/apim/test/files/vhost/1_vhost-config.json");
+		if(APIManagerAdapter.hasAPIManagerVersion("7.6.2 SP3")) { // Starting from version 7.6.2 SP3 it is possible to set a VHost also for unpublished APIs
+			createVariable("expectedReturnCode", "0");
+		} else {
+			createVariable("expectedReturnCode", "87");
+		}
+		swaggerImport.doExecute(context);
+		
+		echo("####### Validate API: '${apiName}' has a been imported and VHost is set #######");
+		http(builder -> builder.client("apiManager").send().get("/proxies").name("api").header("Content-Type", "application/json"));
+		if(APIManagerAdapter.hasAPIManagerVersion("7.6.2 SP3")) {
+			http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
+				.validate("$.[?(@.path=='${apiPath}')].name", "${apiName}")
+				.validate("$.[?(@.path=='${apiPath}')].state", "${status}")
+				.validate("$.[?(@.path=='${apiPath}')].vhost", "${vhost}")
+				.extractFromPayload("$.[?(@.path=='${apiPath}')].id", "apiId"));
+		} else {
+			http(builder -> builder.client("apiManager").receive().response(HttpStatus.OK).messageType(MessageType.JSON)
+					.validate("$.*.name", "@assertThat(not(containsString(${apiName})))@"));
+		}
 	}
 }

--- a/modules/swagger-promote-core/src/test/resources/com/axway/apim/test/files/vhost/2_vhost-config.json
+++ b/modules/swagger-promote-core/src/test/resources/com/axway/apim/test/files/vhost/2_vhost-config.json
@@ -1,0 +1,9 @@
+	
+{
+	"name": "${apiName}",
+	"path": "${apiPath}",
+	"state": "${status}",
+	"vhost": "${vhost}",
+	"version": "1.0.0",
+	"organization": "${vhostOrgName}"
+}


### PR DESCRIPTION
Fixing issue: #98 - VHost is now set again during publish
Additionally added support to set VHost on unpublished API on >7.6.2 SP3