### PR TITLE
setup keystore to retrieve api definition from https endpoint protected by two way ssl

### DIFF
--- a/modules/swagger-promote-core/src/main/java/com/axway/apim/lib/ErrorCode.java
+++ b/modules/swagger-promote-core/src/main/java/com/axway/apim/lib/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
 	WRONG_KEYSTORE_PASSWORD				(81, "The password for the keystore is wrong."),
 	UNKNOWN_CUSTOM_POLICY				(85, "A custom policy-name is unknown (Request-, Routing, ...)"),
 	CANT_SETUP_VHOST					(87, "It wasn't possible to setup the V-Host for the FE-API"),
+	CANT_CREATE_HTTP_CLIENT				(88, "Cannot create HTTP client"),
 	UNXPECTED_ERROR						(99, "An unexpected error occured.");
 
 	private final int code;


### PR DESCRIPTION
the user can configure the launch script by passing the java system property:

-Djavax.net.ssl.keyStore=</path/to/keystore.jks> 
-Djavax.net.ssl.keyStorePassword=<keystore pwd> 
-Djavax.net.ssl.keyStoreType=<keystore type>